### PR TITLE
chore: configure absolute imports

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,19 +1,21 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "Bundler",
-    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
+    "noEmit": false,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
@@ -21,5 +23,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,17 @@
 {
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "src"
+  ],
   "files": [],
   "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,17 +1,18 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "ES2022",
-    "lib": ["ES2023"],
+    "lib": [
+      "ES2023"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
-
+    "noEmit": false,
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
@@ -19,5 +20,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": [
+    "vite.config.ts"
+  ]
 }


### PR DESCRIPTION
This pull request includes changes to improve TypeScript configuration and simplify imports in the main application file. The most important changes include enabling project references, adjusting compiler options, and updating import statements.

### TypeScript Configuration Improvements:

* [`tsconfig.app.json`](diffhunk://#diff-e71ce96b0b270cb476d6bd8c44bf0cdf6f0db749e316374a54f1b14aff8d63ddR3-R28): Enabled project references with the `composite` option and changed `noEmit` to `false` to allow emitting output files.
* [`tsconfig.node.json`](diffhunk://#diff-fe25c5935d7e03a4c85624008426c631b83d3afccbd792e41549cb74ce945118R3-R25): Enabled project references with the `composite` option and changed `noEmit` to `false` to allow emitting output files.

### Codebase Simplification:

* [`src/main.tsx`](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811L4-R4): Simplified the import statement for the `App` component by removing the `.tsx` extension.